### PR TITLE
Fix error if trying to cache routes

### DIFF
--- a/routes/cp.php
+++ b/routes/cp.php
@@ -5,4 +5,4 @@ use Spatie\StatamicMailcoach\Http\Controllers\MailcoachSettingsController;
 
 Route::get('/mailcoach/dashboard', '\\'.MailcoachDashboardController::class)->name('statamic-mailcoach.index');
 Route::get('/mailcoach/settings', ['\\'.MailcoachSettingsController::class, 'show'])->name('statamic-mailcoach.settings');
-Route::post('/mailcoach/settings', ['\\'.MailcoachSettingsController::class, 'store'])->name('statamic-mailcoach.settings');
+Route::post('/mailcoach/settings', ['\\'.MailcoachSettingsController::class, 'store']);


### PR DESCRIPTION
If you install this addon in Statamic and try to cache the routes with `php artisan routes:cache`, the command will fail with the error below. This error occurs because the route names are duplicated and Laravel does not allow this anymore.

```
In AbstractRouteCollection.php line 247:
                                                                               
  Unable to prepare route [cp/mailcoach/settings] for serialization. Another   
  route has already been assigned name [statamic.cp.statamic-mailcoach.settin  
  gs].
```

As far as I've looked through the codebase - nowhere does it address the POST route by name. So removing the name for that route is the easiest way to fix the problem.

It fixes issue #6 