### PR TITLE
Statamic v5 compatibility 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "require": {
         "spatie/laravel-mailcoach-sdk": "^1.0",
         "stillat/proteus": "^v1.0|^v2.1",
-        "statamic/cms": "^3.4|^4.0"
+        "statamic/cms": "^3.4|^4.0|^5.0"
     },
     "extra": {
         "statamic": {

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     },
     "require": {
         "spatie/laravel-mailcoach-sdk": "^1.0",
-        "stillat/proteus": "^v1.0|^v2.1",
+        "stillat/proteus": "^v1.0|^v2.1|^3.0",
         "statamic/cms": "^3.4|^4.0|^5.0"
     },
     "extra": {


### PR DESCRIPTION
Added Statamic v5 compatibility



-----
For testing, add this to composer.json
```json
"repositories": {
    "spatie/laravel-mailcoach" : {
        "type" : "vcs",
        "url": "https://github.com/SRWieZ/fork-spatie-statamic-mailcoach"
    }
},
```

`composer require spatie/statamic-mailcoach "dev-statamic-v5"`